### PR TITLE
Bundle size optimization

### DIFF
--- a/packages/next-server/lib/amp-context.ts
+++ b/packages/next-server/lib/amp-context.ts
@@ -1,3 +1,3 @@
-import * as React from 'react'
+import React from 'react'
 
 export const AmpStateContext: React.Context<any> = React.createContext({})

--- a/packages/next-server/lib/data-manager-context.ts
+++ b/packages/next-server/lib/data-manager-context.ts
@@ -1,3 +1,3 @@
-import * as React from 'react'
+import React from 'react'
 
 export const DataManagerContext: React.Context<any> = React.createContext(null)

--- a/packages/next-server/lib/head-manager-context.ts
+++ b/packages/next-server/lib/head-manager-context.ts
@@ -1,3 +1,3 @@
-import * as React from 'react'
+import React from 'react'
 
 export const HeadManagerContext: React.Context<any> = React.createContext(null)

--- a/packages/next-server/lib/loadable-context.ts
+++ b/packages/next-server/lib/loadable-context.ts
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 
 type CaptureFn = (moduleName: string) => void
 

--- a/packages/next-server/lib/request-context.ts
+++ b/packages/next-server/lib/request-context.ts
@@ -1,3 +1,3 @@
-import * as React from 'react'
+import React from 'react'
 
 export const RequestContext: React.Context<any> = React.createContext(null)

--- a/packages/next-server/lib/router-context.ts
+++ b/packages/next-server/lib/router-context.ts
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { NextRouter } from './router/router'
 
 export const RouterContext = React.createContext<NextRouter>(null as any)

--- a/packages/next-server/tsconfig.json
+++ b/packages/next-server/tsconfig.json
@@ -3,6 +3,7 @@
     "strict": true,
     "module": "esnext",
     "target": "ES2017",
+    "removeComments": true,
     "esModuleInterop": true,
     "moduleResolution": "node",
     "jsx": "react"

--- a/packages/next/build/babel/preset.ts
+++ b/packages/next/build/babel/preset.ts
@@ -7,7 +7,7 @@ const isTest = env === 'test'
 type StyledJsxPlugin = [string, any] | string
 type StyledJsxBabelOptions =
   | {
-      plugins?: StyledJsxPlugin[],
+      plugins?: StyledJsxPlugin[]
       'babel-test'?: boolean
     }
   | undefined
@@ -64,7 +64,10 @@ module.exports = (
     // In the test environment `modules` is often needed to be set to true, babel figures that out by itself using the `'auto'` option
     // In production/development this option is set to `false` so that webpack can handle import/export with tree-shaking
     modules: 'auto',
-    exclude: ['transform-typeof-symbol'],
+    exclude: ['transform-typeof-symbol', '@babel/plugin-transform-regenerator'],
+    loose: isProduction,
+    useBuiltIns: 'usage',
+    corejs: 2,
     ...options['preset-env'],
   }
   return {
@@ -96,16 +99,11 @@ module.exports = (
         },
       ],
       [
-        require('@babel/plugin-transform-runtime'),
-        {
-          corejs: 2,
-          helpers: true,
-          regenerator: true,
-          useESModules: supportsESM && presetEnvConfig.modules !== 'commonjs',
-          ...options['transform-runtime'],
-        },
+        isTest && options['styled-jsx'] && options['styled-jsx']['babel-test']
+          ? require('styled-jsx/babel-test')
+          : require('styled-jsx/babel'),
+        styledJsxOptions(options['styled-jsx']),
       ],
-      [(isTest && options['styled-jsx'] && options['styled-jsx']['babel-test']) ? require('styled-jsx/babel-test') : require('styled-jsx/babel'), styledJsxOptions(options['styled-jsx'])],
       require('./plugins/amp-attributes'),
       isProduction && [
         require('babel-plugin-transform-react-remove-prop-types'),

--- a/packages/next/build/babel/preset.ts
+++ b/packages/next/build/babel/preset.ts
@@ -57,8 +57,7 @@ function supportsStaticESM(caller: any) {
 
 // Enable when module/nomodule ships.
 function isModernBuild(caller: any) {
-  // return !!(caller && caller.isModern);
-  return true
+  return !!(caller && caller.isModern)
 }
 
 module.exports = (

--- a/packages/next/build/babel/preset.ts
+++ b/packages/next/build/babel/preset.ts
@@ -55,11 +55,19 @@ function supportsStaticESM(caller: any) {
   return !!(caller && caller.supportsStaticESM)
 }
 
+// Enable when module/nomodule ships.
+function isModernBuild(caller: any) {
+  // return !!(caller && caller.isModern);
+  return true
+}
+
 module.exports = (
   api: any,
   options: NextBabelPresetOptions = {}
 ): BabelPreset => {
   const supportsESM = api.caller(supportsStaticESM)
+  const isModern = api.caller(isModernBuild)
+
   const presetEnvConfig = {
     // In the test environment `modules` is often needed to be set to true, babel figures that out by itself using the `'auto'` option
     // In production/development this option is set to `false` so that webpack can handle import/export with tree-shaking
@@ -70,32 +78,44 @@ module.exports = (
     corejs: 2,
     ...options['preset-env'],
   }
+
   return {
     presets: [
-      [require('@babel/preset-env').default, presetEnvConfig],
+      isModern
+        ? require('babel-preset-modules')
+        : [require('@babel/preset-env').default, presetEnvConfig],
       [
         require('@babel/preset-react'),
         {
           // This adds @babel/plugin-transform-react-jsx-source and
           // @babel/plugin-transform-react-jsx-self automatically in development
           development: isDevelopment || isTest,
+          useBuiltIns: isModern,
           ...options['preset-react'],
         },
       ],
       require('@babel/preset-typescript'),
     ],
     plugins: [
+      !supportsESM && [
+        require('@babel/plugin-transform-modules-commonjs'),
+        { loose: true },
+      ],
       require('babel-plugin-react-require'),
       require('@babel/plugin-syntax-dynamic-import'),
       require('./plugins/react-loadable-plugin'),
       [
         require('@babel/plugin-proposal-class-properties'),
-        options['class-properties'] || {},
+        {
+          loose: true,
+          ...(options['class-properties'] || {}),
+        },
       ],
       [
         require('@babel/plugin-proposal-object-rest-spread'),
         {
-          useBuiltIns: true,
+          loose: true,
+          useBuiltIns: isModern,
         },
       ],
       [

--- a/packages/next/build/polyfills/date-now.js
+++ b/packages/next/build/polyfills/date-now.js
@@ -1,0 +1,1 @@
+export default Date.now

--- a/packages/next/build/polyfills/fetch.js
+++ b/packages/next/build/polyfills/fetch.js
@@ -1,0 +1,1 @@
+export default window.fetch

--- a/packages/next/build/polyfills/globalThis.js
+++ b/packages/next/build/polyfills/globalThis.js
@@ -1,0 +1,1 @@
+export default global

--- a/packages/next/build/polyfills/is-array.js
+++ b/packages/next/build/polyfills/is-array.js
@@ -1,0 +1,1 @@
+export default Array.isArray

--- a/packages/next/build/polyfills/json-stringify.js
+++ b/packages/next/build/polyfills/json-stringify.js
@@ -1,0 +1,1 @@
+export default JSON.stringify

--- a/packages/next/build/polyfills/map.js
+++ b/packages/next/build/polyfills/map.js
@@ -1,0 +1,1 @@
+export default Map

--- a/packages/next/build/polyfills/object-assign.cjs.js
+++ b/packages/next/build/polyfills/object-assign.cjs.js
@@ -1,0 +1,1 @@
+module.exports = Object.assign

--- a/packages/next/build/polyfills/object-assign.js
+++ b/packages/next/build/polyfills/object-assign.js
@@ -1,0 +1,1 @@
+export default Object.assign

--- a/packages/next/build/polyfills/object-define-property.js
+++ b/packages/next/build/polyfills/object-define-property.js
@@ -1,0 +1,1 @@
+export default Object.defineProperty

--- a/packages/next/build/polyfills/object-get-own-property-descriptor.js
+++ b/packages/next/build/polyfills/object-get-own-property-descriptor.js
@@ -1,0 +1,1 @@
+export default Object.getOwnPropertyDescriptor

--- a/packages/next/build/polyfills/object-keys.js
+++ b/packages/next/build/polyfills/object-keys.js
@@ -1,0 +1,1 @@
+export default Object.keys

--- a/packages/next/build/polyfills/promise.js
+++ b/packages/next/build/polyfills/promise.js
@@ -1,0 +1,1 @@
+export default Promise

--- a/packages/next/build/polyfills/querystring.js
+++ b/packages/next/build/polyfills/querystring.js
@@ -1,0 +1,1 @@
+export { encode, decode } from 'qss'

--- a/packages/next/build/polyfills/set.js
+++ b/packages/next/build/polyfills/set.js
@@ -1,0 +1,1 @@
+export default Set

--- a/packages/next/build/polyfills/url.js
+++ b/packages/next/build/polyfills/url.js
@@ -1,0 +1,88 @@
+import { encode, decode } from './querystring'
+
+const IS_BROWSER = typeof window !== 'undefined'
+
+const BASE_URL = IS_BROWSER ? window.location.href : 'http://baseurl'
+
+module.exports = {
+  // URL,
+  // URLSearchParams: typeof URLSearchParams !== 'undefined' && URLSearchParams,
+
+  parse (url) {
+    let res = new URL(url, BASE_URL)
+    // res.query = res.searchParams;
+    res.query = decode(res.search.substr(1))
+    return res
+  },
+
+  format (urlObj) {
+    let {
+      auth,
+      host,
+      hostname,
+      protocol = '',
+      pathname = '',
+      hash = '',
+      query = ''
+    } = urlObj
+
+    auth = auth ? encodeURIComponent(auth).replace(/%3A/i, ':') + '@' : ''
+
+    if (host) {
+      host = auth + host
+    } else if (hostname) {
+      host = auth + (~hostname.indexOf(':') ? `[${hostname}]` : hostname)
+      if (urlObj.port) {
+        host += ':' + urlObj.port
+      }
+    } else {
+      host = ''
+    }
+
+    if (query && typeof query === 'object') {
+      // query = '' + new URLSearchParams(query);
+      query = encode(query)
+    }
+
+    let search = urlObj.search || (query && `?${query}`)
+
+    if (protocol && protocol.substr(-1) !== ':') protocol += ':'
+
+    // only the slashedProtocols get the //.  Not mailto:, xmpp:, etc.
+    // unless they had them to begin with.
+    if (
+      urlObj.slashes ||
+      ((!protocol || /https?|ftp|gopher|file/.test(protocol)) && host)
+    ) {
+      host = `//${host}`
+      if (pathname && pathname[0] !== '/') pathname = '/' + pathname
+    }
+
+    if (hash && hash[0] !== '#') hash = '#' + hash
+    if (search && search[0] !== '?') search = '?' + search
+
+    pathname = pathname.replace(/[?#]/g, encodeURIComponent)
+    search = search.replace('#', '%23')
+
+    return `${protocol}${host}${pathname}${search}${hash}`
+  },
+
+  resolve (fromUrl, toUrl) {
+    const normalizedFromUrl = new URL(fromUrl, BASE_URL)
+    return '' + new URL(toUrl, normalizedFromUrl)
+  }
+}
+
+// console.log(Url.parse('/test/1?a=1'));
+// console.log(Url.format({
+//   protocol: 'https',
+//   hostname: 'example.com',
+//   pathname: '/some/path',
+//   query: {
+//     page: 1,
+//     format: 'json'
+//   }
+// }));
+
+// console.log(Url.resolve('/one/two/three', 'four'));
+// console.log(Url.resolve('http://example.com/', '/one'));

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -177,7 +177,7 @@ export default async function getBaseWebpackConfig(
             'querystring-es3': 'qss',
           }),
     },
-    mainFields: isServer ? ['main', 'module'] : ['browser', 'module', 'main'],
+    mainFields: isServer ? ['main', 'module'] : ['module', 'browser', 'main'],
   }
 
   const webpackMode = dev ? 'development' : 'production'

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -514,6 +514,11 @@ export default async function getBaseWebpackConfig(
         'process.env.__NEXT_EXPORT_TRAILING_SLASH': JSON.stringify(
           config.exportTrailingSlash
         ),
+        ...(dev
+          ? {}
+          : {
+              'module.hot': 'undefined',
+            }),
         ...(isServer
           ? {
               // Allow browser-only code to be eliminated
@@ -526,6 +531,8 @@ export default async function getBaseWebpackConfig(
           : {
               // Allow server-only code to be eliminated
               'typeof window': JSON.stringify('object'),
+
+              process: '{}',
             }),
       }),
       !isServer &&

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -535,8 +535,6 @@ export default async function getBaseWebpackConfig(
           : {
               // Allow server-only code to be eliminated
               'typeof window': JSON.stringify('object'),
-
-              process: '{}',
             }),
       }),
       !isServer &&

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -139,6 +139,43 @@ export default async function getBaseWebpackConfig(
       next: NEXT_PROJECT_ROOT,
       [PAGES_DIR_ALIAS]: path.join(dir, 'pages'),
       [DOT_NEXT_ALIAS]: distDir,
+      'whatwg-fetch': 'next/dist/build/polyfills/fetch.js',
+      unfetch: 'next/dist/build/polyfills/fetch.js',
+      'isomorphic-unfetch': 'next/dist/build/polyfills/fetch.js',
+
+      'object-assign': 'next/dist/build/polyfills/object-assign.cjs.js',
+      '@babel/runtime-corejs2/core-js/map': 'next/dist/build/polyfills/map.js',
+      '@babel/runtime-corejs2/core-js/set': 'next/dist/build/polyfills/set.js',
+      '@babel/runtime-corejs2/core-js/object/assign':
+        'next/dist/build/polyfills/object-assign.js',
+      '@babel/runtime-corejs2/core-js/object/define-property':
+        'next/dist/build/polyfills/object-define-property.js',
+      'core-js/library/fn/object/define-property':
+        'next/dist/build/polyfills/object-define-property.js',
+      '@babel/runtime-corejs2/core-js/object/get-own-property-descriptor':
+        'next/dist/build/polyfills/object-get-own-property-descriptor.js',
+      'core-js/library/fn/object/get-own-property-descriptor':
+        'next/dist/build/polyfills/object-get-own-property-descriptor.js',
+      '@babel/runtime-corejs2/core-js/promise':
+        'next/dist/build/polyfills/promise.js',
+
+      'core-js/library/modules/_global':
+        'next/dist/build/polyfills/globalThis.js',
+      '@babel/runtime-corejs2/core-js/json/stringify':
+        'next/dist/build/polyfills/json-stringify.js',
+      '@babel/runtime-corejs2/core-js/date/now':
+        'next/dist/build/polyfills/date-now.js',
+      '@babel/runtime-corejs2/core-js/array/is-array':
+        'next/dist/build/polyfills/is-array.js',
+
+      ...(isServer
+        ? {}
+        : {
+            // on the client, polyfill Node `url` and `querystring` using URL:
+            url: 'next/dist/build/polyfills/url.js',
+            querystring: 'qss',
+            'querystring-es3': 'qss',
+          }),
     },
     mainFields: isServer ? ['main', 'module'] : ['browser', 'module', 'main'],
   }
@@ -305,6 +342,16 @@ export default async function getBaseWebpackConfig(
                       name: 'commons',
                       chunks: 'all',
                       test: /[\\/]node_modules[\\/](react|react-dom)[\\/]/,
+                    },
+                    // Float widely used next client-side libraries (router, page loader) into the runtime chunk
+                    // This ensures the runtime chunk contains the most common libs, which prevents it from being
+                    // inefficiently small. We don't want any universally required chunks to be <10kb.
+                    next: {
+                      name: 'commons',
+                      chunks: 'all',
+                      test: /[\\/]next-server[\\/]dist[\\/]|[\\/]next[\\/]dist[\\/](client|build)[\\/]|[\\/]node_modules[\\/](styled-jsx|qss)[\\/]/,
+                      priority: 100,
+                      minChunks: 2,
                     },
                   },
                 },

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -336,7 +336,7 @@ export default async function getBaseWebpackConfig(
                     react: {
                       name: 'commons',
                       chunks: 'all',
-                      test: /[\\/]node_modules[\\/](react|react-dom)[\\/]/,
+                      test: /[\\/]node_modules[\\/](react|react-dom|scheduler)[\\/]/,
                     },
                   },
                 }
@@ -353,7 +353,7 @@ export default async function getBaseWebpackConfig(
                     react: {
                       name: 'commons',
                       chunks: 'all',
-                      test: /[\\/]node_modules[\\/](react|react-dom)[\\/]/,
+                      test: /[\\/]node_modules[\\/](react|react-dom|scheduler|prop-types)[\\/]/,
                     },
                     // Float widely used next client-side libraries (router, page loader) into the runtime chunk
                     // This ensures the runtime chunk contains the most common libs, which prevents it from being

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -217,6 +217,18 @@ export default async function getBaseWebpackConfig(
     mode: webpackMode,
     name: isServer ? 'server' : 'client',
     target: isServer ? 'node' : 'web',
+    node: isServer
+      ? undefined
+      : {
+          console: false,
+          global: true,
+          process: false,
+          __filename: 'mock',
+          __dirname: 'mock',
+          Buffer: false,
+          setImmediate: false,
+        },
+
     externals: !isServer
       ? undefined
       : target !== 'serverless'

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -56,11 +56,15 @@ export default async function getBaseWebpackConfig(
   }
 ): Promise<webpack.Configuration> {
   const distDir = path.join(dir, config.distDir)
+
+  const isModern = !!config.experimental.modern
+
   const defaultLoaders = {
     babel: {
       loader: 'next-babel-loader',
       options: {
         isServer,
+        isModern,
         distDir,
         cwd: dir,
         cache: !selectivePageBuilding,
@@ -194,7 +198,7 @@ export default async function getBaseWebpackConfig(
       ecma: 8,
     },
     compress: {
-      ecma: 5,
+      ecma: isModern ? 8 : 5,
       warnings: false,
       // The following two options are known to break valid JavaScript code
       comparisons: false,
@@ -202,7 +206,7 @@ export default async function getBaseWebpackConfig(
     },
     mangle: { safari10: true },
     output: {
-      ecma: 5,
+      ecma: isModern ? 8 : 5,
       safari10: true,
       comments: false,
       // Fixes usage of Emoji and certain Regex

--- a/packages/next/build/webpack/loaders/next-babel-loader.js
+++ b/packages/next/build/webpack/loaders/next-babel-loader.js
@@ -148,8 +148,7 @@ module.exports = babelLoader.custom(babel => {
         {
           test: [
             /next-server[\\/]dist[\\/]lib/,
-            /next[\\/]dist[\\/]client/,
-            /next[\\/]dist[\\/]pages/
+            /next[\\/]dist[\\/](client|pages|build)[\\/]/
           ],
           plugins: [commonJsItem]
         }

--- a/packages/next/build/webpack/loaders/next-babel-loader.js
+++ b/packages/next/build/webpack/loaders/next-babel-loader.js
@@ -24,6 +24,7 @@ module.exports = babelLoader.custom(babel => {
     customOptions (opts) {
       const custom = {
         isServer: opts.isServer,
+        isModern: opts.isModern,
         asyncToPromises: opts.asyncToPromises
       }
       const filename = join(opts.cwd, 'noop.js')
@@ -49,6 +50,7 @@ module.exports = babelLoader.custom(babel => {
       )
 
       delete loader.isServer
+      delete loader.isModern
       delete loader.asyncToPromises
       delete loader.cache
       delete loader.distDir
@@ -58,7 +60,7 @@ module.exports = babelLoader.custom(babel => {
       cfg,
       {
         source,
-        customOptions: { isServer, asyncToPromises }
+        customOptions: { isServer, isModern, asyncToPromises }
       }
     ) {
       const { cwd } = cfg.options
@@ -79,6 +81,8 @@ module.exports = babelLoader.custom(babel => {
         // Add our default preset if the no "babelrc" found.
         options.presets = [...options.presets, presetItem]
       }
+
+      options.caller.isModern = isModern
 
       if (!isServer && isPageFile) {
         const pageConfigPlugin = babel.createConfigItem(

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -75,6 +75,7 @@
     "babel-plugin-react-require": "3.0.0",
     "babel-plugin-transform-async-to-promises": "0.8.10",
     "babel-plugin-transform-react-remove-prop-types": "0.4.24",
+    "babel-preset-modules": "^0.0.1",
     "chalk": "2.4.2",
     "find-up": "4.0.0",
     "fork-ts-checker-webpack-plugin": "1.3.4",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -101,7 +101,8 @@
     "webpack-dev-middleware": "3.7.0",
     "webpack-hot-middleware": "2.25.0",
     "webpack-sources": "1.3.0",
-    "worker-farm": "1.7.0"
+    "worker-farm": "1.7.0",
+    "qss": "^2.0.3"
   },
   "peerDependencies": {
     "react": "^16.6.0",

--- a/packages/next/taskfile.js
+++ b/packages/next/taskfile.js
@@ -3,31 +3,19 @@ const relative = require('path').relative
 
 const babelClientOpts = {
   presets: [
+    'babel-preset-modules',
     '@babel/preset-typescript',
     [
-      '@babel/preset-env',
+      '@babel/preset-react',
       {
-        modules: 'commonjs',
-        targets: {
-          esmodules: true
-        },
-        loose: true,
-        exclude: ['transform-typeof-symbol']
-      }
-    ],
-    '@babel/preset-react'
-  ],
-  plugins: [
-    ['@babel/plugin-proposal-class-properties', { loose: true }],
-    [
-      '@babel/plugin-transform-runtime',
-      {
-        corejs: 2,
-        helpers: true,
-        regenerator: false,
-        useESModules: false
+        useBuiltIns: true,
+        loose: true
       }
     ]
+  ],
+  plugins: [
+    ['@babel/plugin-transform-modules-commonjs', { loose: true }],
+    ['@babel/plugin-proposal-class-properties', { loose: true }]
   ]
 }
 

--- a/packages/next/tsconfig.json
+++ b/packages/next/tsconfig.json
@@ -3,6 +3,7 @@
     "strict": true,
     "module": "esnext",
     "target": "ES2017",
+    "removeComments": true,
     "esModuleInterop": true,
     "moduleResolution": "node",
     "jsx": "react"

--- a/test/integration/basic/next.config.js
+++ b/test/integration/basic/next.config.js
@@ -1,10 +1,13 @@
 const path = require('path')
-module.exports = {
+const analyze = process.env.ANALYZE ? require('@next/bundle-analyzer') : Object
+
+module.exports = analyze({
   onDemandEntries: {
     // Make sure entries are not getting disposed.
     maxInactiveAge: 1000 * 60 * 60
   },
   experimental: {
+    modern: !!process.env.MODERN,
     publicDirectory: true
   },
   webpack (config) {
@@ -15,4 +18,4 @@ module.exports = {
 
     return config
   }
-}
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -2901,6 +2901,16 @@ babel-preset-jest@^24.6.0:
     "@babel/plugin-syntax-object-rest-spread" "^7.0.0"
     babel-plugin-jest-hoist "^24.6.0"
 
+babel-preset-modules@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/babel-preset-modules/-/babel-preset-modules-0.0.1.tgz#01ce4c6129941970aaa5ebce1353ab4467c1b952"
+  integrity sha512-P1vr7OJK7L/RZwwaPJP+AsLOdpwcAD2wjfwbvQnqRSKP8lvqDI3YqBhRcCRmxUd5vvuoQRGkzayqz07eUX5tPA==
+  dependencies:
+    "@babel/plugin-proposal-unicode-property-regex" "^7.4.4"
+    "@babel/plugin-transform-dotall-regex" "^7.4.4"
+    "@babel/types" "^7.4.4"
+    esutils "^2.0.2"
+
 babel-runtime@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
@@ -10713,6 +10723,11 @@ qs@~6.5.1, qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
+
+qss@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/qss/-/qss-2.0.3.tgz#630b38b120931b52d04704f3abfb0f861604a9ec"
+  integrity sha512-j48ZBT5IZbSqJiSU8EX4XrN8nXiflHvmMvv2XpFc31gh7n6EpSs75bNr6+oj3FOLWyT8m09pTmqLNl34L7/uPQ==
 
 querystring-es3@^0.2.0:
   version "0.2.1"


### PR DESCRIPTION
This pull request reduces the total JS size of a Next.js application down by as much as 65%. It achieves this for modern JavaScript output, which means it's best paired with @janicklas-ralph's module/nomodule PR.

Here's a summary the changes:

- **Compile out all inlined polyfills.** This is possible because they're not needed for ES Modules-supporting browsers. A legacy bundle with polyfills and ES5 syntax can be generated and served to these browers.
- **Switch to _modern_ modern JavaScript.** This achieves a ~20% size reduction by avoiding over-transpilation due to jagged browser support, while still remaining fully functional (and more debuggable!) in the necessary browsers - Edge 15, Safari 10.1, Firefox 60 & Chrome 61.
- **Ship `next/*` client libraries as modern JS.** This was already being done in part, but I've further reduced their size by tuning all configurations. Client-side next modules are processed by the same Babel configuration as userland JavaScript code, so it's okay to assume a baseline of ES2018 support.
- **Move global modules into the commons chunk.** @atcastle has a much more comprehensive PR for this, my goal here was simply to correct a few of the most notable chunking issues present in applications as simple as the `basic` integration test app. This amounts to moving `scheduler` and `next/*` packages into the commons chunk.
- **Build tuning.** There were a few cases where Next was relying on runtime features that were statically known at build time. For example, the webpack loader responsible for wrapping page chunks with autoregistration wraps its HMR logic in `if (module.hot) {}` - using `DefinePlugin` to replace `module.hot=false` during production builds removes the unnecessary HMR code from every route. Similarly, Webpack's default behavior is to inject shims for various Node features (`setImmediate`, `Buffer`, etc). While it's possible some users would like to have these available, the fact that they're not used by Next.js itself means it would make more sense to include them conditionally (via config or usage detection).

To test out the changes:

```sh
# download & install:
git clone https://github.com/developit/next.js.git next-lite && cd next-lite
git checkout -b bundle-size-optimization origin/bundle-size-optimization
yarn && npm i -g gzip-sizes

# run a build everything:
yarn run prepublish &&
  rm -rf test/integration/basic/.next &&
  yarn run next build test/integration/basic

# show the output sizes:
gzip-sizes -d test/integration/basic/.next/static -s size- "**/*.js"
```